### PR TITLE
Use shutil.copy instead of os.system('cp ...') for CV output files

### DIFF
--- a/mlatom/MLtasks.py
+++ b/mlatom/MLtasks.py
@@ -818,10 +818,10 @@ def sampling(args=None, XYZfile=None, XfileIn=None, sampling=None, Nuse=None,
             if os.path.exists(tmpdirname + '/icvtest1.dat'):  args.iCVtestPrefIn = tmpdirname + '/icvtest'
             if os.path.exists(tmpdirname + '/icvopt1.dat'):   args.iCVoptPrefIn  = tmpdirname + '/icvopt'
             if os.path.exists(tmpdirname + '/icvtest1icvopt1.dat'):   args.iCVoptPrefIn  = 'icvopt'
-            if iTrainOut:      os.system(f'cp {tmpdirname}/itrain.dat {iTrainOut}')
-            if iSubtrainOut:   os.system(f'cp {tmpdirname}/isubtrain.dat {iSubtrainOut}')
-            if iValidateOut:   os.system(f'cp {tmpdirname}/ivalidate.dat {iValidateOut}')
-            if iTestOut:       os.system(f'cp {tmpdirname}/itest.dat {iTestOut}')
+            if iTrainOut:      shutil.copy(os.path.join(tmpdirname, 'itrain.dat'), iTrainOut)
+            if iSubtrainOut:   shutil.copy(os.path.join(tmpdirname, 'isubtrain.dat'), iSubtrainOut)
+            if iValidateOut:   shutil.copy(os.path.join(tmpdirname, 'ivalidate.dat'), iValidateOut)
+            if iTestOut:       shutil.copy(os.path.join(tmpdirname, 'itest.dat'), iTestOut)
             if args.CVtest and iCVtestPrefOut: 
                 if args.CVopt and iCVoptPrefOut:
                     os.system(f"find {tmpdirname} -name '*icvopt*' -exec bash -c ' mv $0 ${{0/\"icvopt\"/\"{iCVoptPrefOut}\"}}' {{}} \;")


### PR DESCRIPTION
The train/subtrain/validate/test output files were copied with `os.system` and an f-string-interpolated path:

```python
os.system(f"cp {tmpdirname}/itrain.dat {iTrainOut}")
```

This breaks when the output path (`iTrainOut`, …) contains spaces or shell metacharacters, and is Unix-only. Replaced the four copies with `shutil.copy` + `os.path.join` (`shutil` is already imported), so they are shell-free, robust to special characters, and portable. Behavior is otherwise unchanged.