### PR TITLE
Add timeouts to model-download HTTP requests

### DIFF
--- a/mlatom/interfaces/torchani_interface.py
+++ b/mlatom/interfaces/torchani_interface.py
@@ -1934,7 +1934,7 @@ def load_ani1xnr_model():
         if not os.path.exists(local_dir+'ani-1xnr-main'):
             os.makedirs(local_dir, exist_ok=True)
             print(f'Downloading ANI-1xnr model parameters ...')
-            resource_res = requests.get(url)
+            resource_res = requests.get(url, timeout=30)
             resource_zip = zipfile.ZipFile(io.BytesIO(resource_res.content))
             resource_zip.extractall(local_dir)
         return local_dir

--- a/mlatom/model_cls.py
+++ b/mlatom/model_cls.py
@@ -284,7 +284,7 @@ class downloadable_model(model):
         assert target is not None, "Please provide target directory to be downloaded"
         print(f'Start downloading model from {link} to {target}'); sys.stdout.flush()
         try:
-            response = requests.get(link, headers=headers, stream=True, allow_redirects=True)
+            response = requests.get(link, headers=headers, stream=True, allow_redirects=True, timeout=30)
             total_size = int(response.headers.get("content-length", 0))
             target += '.temp'
 


### PR DESCRIPTION
## Summary

Two `requests.get()` calls that download model files run without a `timeout`, so a stalled or unresponsive server hangs the MLatom process indefinitely (no way to recover except killing it):

- `mlatom/model_cls.py:287` — downloading a model from a link (streamed).
- `mlatom/interfaces/torchani_interface.py:1937` — fetching the ANI-1xnr parameters zip from GitHub.

## Fix

Add `timeout=30` to both, consistent with the rest of the codebase, which already sets timeouts on its network calls (`MLatom.py` uses `timeout=3`, `_update_check.py` and `_version.py` use timeouts too).

```diff
- requests.get(link, headers=headers, stream=True, allow_redirects=True)
+ requests.get(link, headers=headers, stream=True, allow_redirects=True, timeout=30)
```
```diff
- resource_res = requests.get(url)
+ resource_res = requests.get(url, timeout=30)
```

Note: requests' `timeout` is a per-read inactivity limit, not a total-duration cap, so this does **not** abort slow-but-progressing streamed downloads — it only unblocks the process when the connection goes dead.